### PR TITLE
CLI subcommand to validate

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -32,7 +32,8 @@ export const lspAction = () => {
     startLanguageServer(shared);
 }
 
-export const validateAction = async (fileOrDirName: string) => {
+type ValidateOptions = { Werror: boolean };
+export const validateAction = async (fileOrDirName: string, options: ValidateOptions) => {
     const services = createSnakeskinServices(NodeFileSystem).Snakeskin;
     const docs = await extractDocuments(fileOrDirName, services);
 
@@ -63,7 +64,7 @@ export const validateAction = async (fileOrDirName: string) => {
 
     console.log(color(`Found a total of ${errorsTotal} error(s) and ${warningsTotal} warning(s).`))
 
-    if (errorsTotal > 0) {
+    if (errorsTotal > 0 || (options.Werror && warningsTotal > 0)) {
         process.exit(1);
     }
 }
@@ -90,6 +91,7 @@ export default function(): void {
     program
         .command('validate')
         .argument('[path]', 'source file or directory; globs not supported yet', '.')
+        .option('-Werror', 'fail on warnings as well', false)
         .description('parses and validates Snakeskin files')
         .action(validateAction);
 

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -19,17 +19,6 @@ export async function extractDocument(fileName: string, services: LangiumCoreSer
     const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
     await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
-    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
-    if (validationErrors.length > 0) {
-        console.error(chalk.red('There are validation errors:'));
-        for (const validationError of validationErrors) {
-            console.error(chalk.red(
-                `line ${validationError.range.start.line + 1}: ${validationError.message} [${document.textDocument.getText(validationError.range)}]`
-            ));
-        }
-        process.exit(1);
-    }
-
     return document;
 }
 

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -22,6 +22,21 @@ export async function extractDocument(fileName: string, services: LangiumCoreSer
     return document;
 }
 
+export async function extractDocuments(fileOrDirName: string, services: LangiumCoreServices): Promise<LangiumDocument[]> {
+    if (!fs.existsSync(fileOrDirName)) {
+        console.error(chalk.red(`No such file or directory: ${fileOrDirName}.`));
+        process.exit(1);
+    }
+    if (!fs.lstatSync(fileOrDirName).isDirectory()) {
+        return [await extractDocument(fileOrDirName, services)];
+    }
+    const extensions = services.LanguageMetaData.fileExtensions;
+    const files = fs.readdirSync(fileOrDirName, { encoding:'utf8', recursive: true })
+                    .filter(file => extensions.includes(path.extname(file)));
+    return Promise.all(files.map(file => extractDocument(path.join(fileOrDirName, file), services)));
+}
+
+
 export async function extractAstNode<T extends AstNode>(fileName: string, services: LangiumCoreServices): Promise<T> {
     return (await extractDocument(fileName, services)).parseResult?.value as T;
 }

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CLI subcommand for running validation checks.
+
 ### Fixed
 
 - Some diagnostic messages related to parsing errors around indentation were not being shown.

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -27,12 +27,12 @@
     },
     "scripts": {
         "clean": "shx rm -fr *.tsbuildinfo out",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.src.json",
         "build:clean": "npm run clean && npm run build",
         "langium:generate": "langium generate",
         "langium:watch": "langium generate --watch",
         "test": "vitest run",
-        "watch": "tsc --watch"
+        "watch": "tsc -p tsconfig.src.json --watch"
     },
     "dependencies": {
         "@vue/language-service": "^2.0.29",


### PR DESCRIPTION
Added a command to the CLI to validate the given file or directory and report back diagnostics. Includes a `-Werror` flag for failing on warnings as well. This is useful for CI pipelines.