### PR TITLE
Add "include directive" go to definition and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,6 +1017,102 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1079,6 +1175,16 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1893,7 +1999,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -1903,7 +2008,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -2112,7 +2216,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -2125,7 +2228,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/commander": {
@@ -2205,7 +2307,6 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2330,6 +2431,12 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "license": "MIT"
+        },
         "node_modules/emmet": {
             "version": "2.4.7",
             "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.7.tgz",
@@ -2350,7 +2457,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/entities": {
@@ -2778,6 +2884,22 @@
             "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/fs-extra": {
             "version": "11.1.1",
@@ -3209,7 +3331,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3281,8 +3402,25 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
+        },
+        "node_modules/jackspeak": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+            "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
         },
         "node_modules/js-tokens": {
             "version": "9.0.0",
@@ -3601,6 +3739,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/mlly": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
@@ -3857,6 +4004,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+            "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3900,7 +4053,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3912,6 +4064,31 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+            "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -4299,7 +4476,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -4312,7 +4488,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4374,7 +4549,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -4426,7 +4600,21 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -4441,7 +4629,19 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -5602,7 +5802,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -5646,6 +5845,24 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -5767,6 +5984,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@vue/language-service": "^2.0.29",
+                "glob": "^11.0.0",
                 "langium": "~3.1.1",
                 "vscode-html-languageservice": "^5.3.0"
             },
@@ -5776,6 +5994,44 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "packages/language/node_modules/glob": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+            "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/language/node_modules/minimatch": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/web": {

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Go to definition support for `include` directives.
+- Validation that `include` directive paths exist.
 
 ### Fixed
 

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Go to definition support for `include` directives.
+
 ### Fixed
 
 - Some diagnostic messages related to parsing errors around indentation were not being shown.
-- Parser now allows commas to appear at the beginning of plain text
+- Parser now allows commas to appear at the beginning of plain text.
 
 ## [0.0.4] - 2024-08-15
 

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "@vue/language-service": "^2.0.29",
+        "glob": "^11.0.0",
         "langium": "~3.1.1",
         "vscode-html-languageservice": "^5.3.0"
     },

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -27,12 +27,12 @@
     },
     "scripts": {
         "clean": "shx rm -fr *.tsbuildinfo out",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.src.json",
         "build:clean": "npm run clean && npm run build",
         "langium:generate": "langium generate",
         "langium:watch": "langium generate --watch",
         "test": "vitest run",
-        "watch": "tsc --watch"
+        "watch": "tsc -p tsconfig.src.json --watch"
     },
     "dependencies": {
         "@vue/language-service": "^2.0.29",

--- a/packages/language/src/definition-provider.ts
+++ b/packages/language/src/definition-provider.ts
@@ -1,0 +1,33 @@
+import { AstUtils, LeafCstNode, MaybePromise, UriUtils } from "langium";
+import { DefaultDefinitionProvider } from "langium/lsp";
+import { SnakeskinServices } from "./snakeskin-module";
+import { DefinitionParams, LocationLink, Range } from 'vscode-languageserver';
+import { isInclude } from "./generated/ast";
+import { TypeScriptServices } from "./typescript-service";
+
+export class SnakeskinDefinitionProvider extends DefaultDefinitionProvider {
+    protected ts: TypeScriptServices;
+
+    constructor(services: SnakeskinServices) {
+        super(services);
+        this.ts = services.TypeScript;
+    }
+
+    protected override collectLocationLinks(sourceCstNode: LeafCstNode, params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {
+        const node = sourceCstNode.astNode;
+        if (isInclude(node)) {
+            const doc = AstUtils.getDocument(node);
+            const importTargets = this.ts.resolveSnakeskinInclude(node.path, doc.uri.path);
+
+            return importTargets.map(target => LocationLink.create(
+                // The import target is converted to URI (even though it is already an absolute path) to match the format used
+                // by the indexManager, which is the string version of a URI (the main difference is that it includes the protocol)
+                UriUtils.resolvePath(doc.uri, target).toString(),
+                Range.create(0, 0, 0, 0),
+                Range.create(0, 0, 0, 0),
+                sourceCstNode.range,
+            ));
+        }
+        return super.collectLocationLinks(sourceCstNode, params);
+    }
+}

--- a/packages/language/src/definition-provider.ts
+++ b/packages/language/src/definition-provider.ts
@@ -17,7 +17,7 @@ export class SnakeskinDefinitionProvider extends DefaultDefinitionProvider {
         const node = sourceCstNode.astNode;
         if (isInclude(node)) {
             const doc = AstUtils.getDocument(node);
-            const importTargets = this.ts.resolveSnakeskinInclude(node.path, doc.uri.path);
+            const importTargets = this.ts.resolveSnakeskinInclude(node.path, doc.uri);
 
             return importTargets.map(target => LocationLink.create(
                 // The import target is converted to URI (even though it is already an absolute path) to match the format used

--- a/packages/language/src/snakeskin-module.ts
+++ b/packages/language/src/snakeskin-module.ts
@@ -35,7 +35,7 @@ export const SnakeskinModule: Module<SnakeskinServices, PartialLangiumServices &
         Lexer: (services) => new SnakeskinLexer(services),
     },
     validation: {
-        SnakeskinValidator: () => new SnakeskinValidator(),
+        SnakeskinValidator: (services) => new SnakeskinValidator(services),
     },
     lsp: {
         SemanticTokenProvider: (services) => new SemanticTokenProvider(services),

--- a/packages/language/src/snakeskin-module.ts
+++ b/packages/language/src/snakeskin-module.ts
@@ -7,6 +7,7 @@ import { SemanticTokenProvider } from './semantic-tokens.js';
 import { HoverProvider } from './hover-provider.js';
 import { TypeScriptServices } from './typescript-service.js';
 import { SnakeskinDefinitionProvider } from './definition-provider.js';
+import { SnakeskinWorkspaceManager } from './workspace-manager.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -18,11 +19,17 @@ export type SnakeskinAddedServices = {
     TypeScript: TypeScriptServices,
 }
 
+export type SnakeskinSharedServices = {
+    workspace: {
+        WorkspaceManager: SnakeskinWorkspaceManager;
+    };
+};
+
 /**
  * Union of Langium default services and your custom services - use this as constructor parameter
  * of custom service classes.
  */
-export type SnakeskinServices = LangiumServices & SnakeskinAddedServices
+export type SnakeskinServices = LangiumServices & SnakeskinAddedServices & { shared: SnakeskinSharedServices };
 
 /**
  * Dependency injection module that overrides Langium default services and contributes the
@@ -43,6 +50,12 @@ export const SnakeskinModule: Module<SnakeskinServices, PartialLangiumServices &
         DefinitionProvider: (services) => new SnakeskinDefinitionProvider(services),
     },
     TypeScript: (services) => new TypeScriptServices(services),
+};
+
+export const SnakeskinSharedModule: Module<LangiumSharedServices, SnakeskinSharedServices> = {
+    workspace: {
+        WorkspaceManager: (services) => new SnakeskinWorkspaceManager(services),
+    },
 };
 
 /**
@@ -66,7 +79,8 @@ export function createSnakeskinServices(context: DefaultSharedModuleContext): {
 } {
     const shared = inject(
         createDefaultSharedModule(context),
-        SnakeskinGeneratedSharedModule
+        SnakeskinGeneratedSharedModule,
+        SnakeskinSharedModule,
     );
     const Snakeskin = inject(
         createDefaultModule({ shared }),

--- a/packages/language/src/snakeskin-module.ts
+++ b/packages/language/src/snakeskin-module.ts
@@ -6,6 +6,7 @@ import { SnakeskinTokenBuilder, SnakeskinLexer } from './parser/snakeskin-lexer.
 import { SemanticTokenProvider } from './semantic-tokens.js';
 import { HoverProvider } from './hover-provider.js';
 import { TypeScriptServices } from './typescript-service.js';
+import { SnakeskinDefinitionProvider } from './definition-provider.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -39,6 +40,7 @@ export const SnakeskinModule: Module<SnakeskinServices, PartialLangiumServices &
     lsp: {
         SemanticTokenProvider: (services) => new SemanticTokenProvider(services),
         HoverProvider: (services) => new HoverProvider(services),
+        DefinitionProvider: (services) => new SnakeskinDefinitionProvider(services),
     },
     TypeScript: (services) => new TypeScriptServices(services),
 };

--- a/packages/language/src/snakeskin-module.ts
+++ b/packages/language/src/snakeskin-module.ts
@@ -5,6 +5,7 @@ import { SnakeskinValidator, registerValidationChecks } from './snakeskin-valida
 import { SnakeskinTokenBuilder, SnakeskinLexer } from './parser/snakeskin-lexer.js';
 import { SemanticTokenProvider } from './semantic-tokens.js';
 import { HoverProvider } from './hover-provider.js';
+import { TypeScriptServices } from './typescript-service.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -12,7 +13,8 @@ import { HoverProvider } from './hover-provider.js';
 export type SnakeskinAddedServices = {
     validation: {
         SnakeskinValidator: SnakeskinValidator
-    }
+    },
+    TypeScript: TypeScriptServices,
 }
 
 /**
@@ -38,6 +40,7 @@ export const SnakeskinModule: Module<SnakeskinServices, PartialLangiumServices &
         SemanticTokenProvider: (services) => new SemanticTokenProvider(services),
         HoverProvider: (services) => new HoverProvider(services),
     },
+    TypeScript: (services) => new TypeScriptServices(services),
 };
 
 /**

--- a/packages/language/src/snakeskin-validator.ts
+++ b/packages/language/src/snakeskin-validator.ts
@@ -75,7 +75,7 @@ export class SnakeskinValidator {
     validateIncludePath(include: Include, accept: ValidationAcceptor): void {
         const doc = AstUtils.getDocument(include);
         const path = include.path;
-        const importTargets = this.ts.resolveSnakeskinInclude(path, doc.uri.path);
+        const importTargets = this.ts.resolveSnakeskinInclude(path, doc.uri);
 
         if (importTargets.length === 0) {
             accept('error', 'Cannot resolve import', {

--- a/packages/language/src/snakeskin-validator.ts
+++ b/packages/language/src/snakeskin-validator.ts
@@ -1,6 +1,7 @@
-import type { ValidationAcceptor, ValidationChecks } from 'langium';
-import type { SnakeskinAstType, Attribute } from './generated/ast.js';
+import { AstUtils, type ValidationAcceptor, type ValidationChecks } from 'langium';
+import type { SnakeskinAstType, Attribute, Include } from './generated/ast.js';
 import type { SnakeskinServices } from './snakeskin-module.js';
+import type { TypeScriptServices } from './typescript-service.js';
 
 /**
  * Register custom validation checks.
@@ -10,6 +11,7 @@ export function registerValidationChecks(services: SnakeskinServices) {
     const validator = services.validation.SnakeskinValidator;
     const checks: ValidationChecks<SnakeskinAstType> = {
         Attribute: [validator.validateAttributesMissingBar],
+        Include: [validator.validateIncludePath],
     };
     registry.register(checks, validator);
 }
@@ -18,6 +20,11 @@ export function registerValidationChecks(services: SnakeskinServices) {
  * Implementation of custom validations.
  */
 export class SnakeskinValidator {
+    private ts: TypeScriptServices;
+
+    constructor(services: SnakeskinServices) {
+        this.ts = services.TypeScript;
+    }
 
     /**
      * Check for possibly missing a  ' | ' after an attribute value by finding a line in the value
@@ -59,6 +66,22 @@ export class SnakeskinValidator {
                     },
                 }
             );
+        }
+    }
+
+    /**
+     * Checks that the include path actually exists
+     */
+    validateIncludePath(include: Include, accept: ValidationAcceptor): void {
+        const doc = AstUtils.getDocument(include);
+        const path = include.path;
+        const importTargets = this.ts.resolveSnakeskinInclude(path, doc.uri.path);
+
+        if (importTargets.length === 0) {
+            accept('error', 'Cannot resolve import', {
+                node: include,
+                property: 'path',
+            });
         }
     }
 

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
 import { globSync } from "glob";
+import { URI } from "langium";
 import type { SnakeskinServices } from "./snakeskin-module";
 
 export class TypeScriptServices {
@@ -86,12 +87,13 @@ export class TypeScriptServices {
      * @param containingFile The path of the file in which the include directive is used
      * @returns The resolved absolute path(s). Can be an array due to possibility of globs.
      */
-    resolveSnakeskinInclude(includePath: string, containingFile: string): string[] {
+    resolveSnakeskinInclude(includePath: string, containingFileUri: URI): string[] {
         if (this.options == null) {
             return [];
         }
         // Ignore the 'as' part (not relevant for path resolution)
         includePath = includePath.split(':')[0];
+        const containingFile = containingFileUri.path;
 
         if (includePath.endsWith('.ss')) {
             // Importing a specific file directly

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -100,11 +100,11 @@ export class TypeScriptServices {
             // Importing a directory
             // 1- Try appending the final dirname with .ss extension
             const attempt1 = this.resolveSnakeskinIncludeHelper(`${includePath}/${path.basename(includePath)}.ss`, containingFile, this.options);
-            if (attempt1 != null) { return attempt1; }
+            if (attempt1.length > 0) { return attempt1; }
 
             // 2- Try appending "main.ss"
             const attempt2 = this.resolveSnakeskinIncludeHelper(`${includePath}/main.ss`, containingFile, this.options);
-            if (attempt2 != null) { return attempt2; }
+            if (attempt2.length > 0) { return attempt2; }
 
             // 3- Try appending "index.ss"
             const attempt3 = this.resolveSnakeskinIncludeHelper(`${includePath}/index.ss`, containingFile, this.options);

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import { globSync } from "glob";
+import type { SnakeskinServices } from "./snakeskin-module";
+
+export class TypeScriptServices {
+    protected readonly languageService: ts.LanguageService;
+    protected readonly options: ts.CompilerOptions;
+
+    constructor(services: SnakeskinServices) {
+        this.options = TypeScriptServices.getCompilerOptions();
+
+        const host: ts.LanguageServiceHost = {
+            getCompilationSettings: () => this.options,
+            getScriptFileNames: () => {
+                // TODO
+                return [];
+            },
+            getScriptVersion: (fileName: string) => {
+                // TODO
+                return '0';
+            },
+            getScriptSnapshot: (fileName: string) => {
+                // TODO: check if this implementation is correct
+                if (!ts.sys.fileExists(fileName)) { return; }
+                return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, { encoding: 'utf-8' }));
+            },
+            getCurrentDirectory: ts.sys.getCurrentDirectory,
+            getDefaultLibFileName: ts.getDefaultLibFilePath,
+            fileExists: ts.sys.fileExists,
+            readFile: ts.sys.readFile,
+        };
+
+        const docRegistry = ts.createDocumentRegistry(ts.sys.useCaseSensitiveFileNames, ts.sys.getCurrentDirectory());
+
+        this.languageService = ts.createLanguageService(host, docRegistry);
+    };
+
+    private static getCompilerOptions(): ts.CompilerOptions {
+        const currentDir = ts.sys.getCurrentDirectory();
+        const path = ts.findConfigFile(currentDir, ts.sys.fileExists);
+        if (path == null) {
+            return ts.getDefaultCompilerOptions();
+        }
+        const json = ts.parseJsonText(path, fs.readFileSync(path, { encoding: 'utf-8' }));
+        const parsed = ts.parseJsonSourceFileConfigFileContent(json, ts.sys, currentDir);
+        return parsed.options;
+    }
+
+    private static readonly snakeskinModuleResolutionHost: ts.ModuleResolutionHost = {
+        fileExists: (path) => {
+            path = path.replace('.ss.ts', '.ss');
+            if (path.includes('*')) {
+                const matches = globSync(path);
+                return matches.length > 0;
+            }
+            return ts.sys.fileExists(path);
+        },
+        readFile: ts.sys.readFile,
+    };
+
+    /**
+     * Internal helper for {@link resolveSnakeskinInclude} to minmize repetition.
+     */
+    private resolveSnakeskinIncludeHelper(includePath: string, containingFile: string, options: ts.CompilerOptions): string[] {
+        const { resolvedModule } = ts.resolveModuleName(includePath, containingFile, options, TypeScriptServices.snakeskinModuleResolutionHost);
+        let { resolvedFileName } = resolvedModule ?? {};
+
+        if (resolvedFileName == null) return [];
+
+        resolvedFileName = resolvedFileName.replace('.ss.ts', '.ss');
+
+        if (resolvedFileName.includes('*')) {
+            return globSync(resolvedFileName);
+        }
+        return [resolvedFileName];
+    }
+
+    /**
+     * Attempts to resolve includes in Snakeskin (with glob support).
+     * Currently, this is specific to the usage in V4Fire and assumes the usage of the 'b' filter.
+     * It reuses the resolution algorithm of TypeScript instead of reimplementing the exact logic of the 'b' filter.
+     *
+     * @param includePath The path specified in the include directive
+     * @param containingFile The path of the file in which the include directive is used
+     * @returns The resolved absolute path(s). Can be an array due to possibility of globs.
+     */
+    resolveSnakeskinInclude(includePath: string, containingFile: string): string[] {
+        if (this.options == null) {
+            return [];
+        }
+
+        if (includePath.endsWith('.ss')) {
+            // Importing a specific file directly
+            return this.resolveSnakeskinIncludeHelper(includePath, containingFile, this.options);
+        } else {
+            // Importing a directory
+            // 1- Try appending the final dirname with .ss extension
+            const attempt1 = this.resolveSnakeskinIncludeHelper(`${includePath}/${path.basename(includePath)}.ss`, containingFile, this.options);
+            if (attempt1 != null) { return attempt1; }
+
+            // 2- Try appending "main.ss"
+            const attempt2 = this.resolveSnakeskinIncludeHelper(`${includePath}/main.ss`, containingFile, this.options);
+            if (attempt2 != null) { return attempt2; }
+
+            // 3- Try appending "index.ss"
+            const attempt3 = this.resolveSnakeskinIncludeHelper(`${includePath}/index.ss`, containingFile, this.options);
+            return attempt3;
+        }
+    }
+}

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -90,6 +90,8 @@ export class TypeScriptServices {
         if (this.options == null) {
             return [];
         }
+        // Ignore the 'as' part (not relevant for path resolution)
+        includePath = includePath.split(':')[0];
 
         if (includePath.endsWith('.ss')) {
             // Importing a specific file directly

--- a/packages/language/src/workspace-manager.ts
+++ b/packages/language/src/workspace-manager.ts
@@ -1,0 +1,7 @@
+import { DefaultWorkspaceManager } from "langium"
+
+export class SnakeskinWorkspaceManager extends DefaultWorkspaceManager {
+  get workspaceFolders() {
+    return this.folders ?? [];
+  }
+}


### PR DESCRIPTION
Added support for "go to definition" for `- include` directives, and validation that the included path exists