### PR TITLE
Basic TypeScript generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "private": true,
     "scripts": {
         "clean": "npm run clean --workspaces",
-        "watch": "npm run watch --workspace packages/cli --workspace packages/extension --workspace packages/language",
+        "watch": "concurrently -n language,extension \"npm run watch --workspace packages/language\" \"npm run watch --workspace packages/extension\"",
         "build": "npm run build --workspaces",
         "build:clean": "npm run clean && npm run build",
         "lint": "eslint ./packages/*/src --no-error-on-unmatched-pattern --ext ts",

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor improvements to the grammar to fix some of the ambiguities.
 - Improve hover highlight range for tags and attributes
+- Resolve relative path `include`s.
 
 ### Changed
 

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -1,4 +1,4 @@
-import type { LanguageClientOptions, ServerOptions} from 'vscode-languageclient/node.js';
+import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import type * as vscode from 'vscode';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -38,8 +38,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         middleware: {
             handleDiagnostics(uri, diagnostics, next) {
                 const messagesToSuppress = [
-                    'Expecting end of file but found `DEDENT`.',
-                    "Expecting token of type 'EOF' but found `DEDENT`.",
                     "Expecting token of type 'DEDENT' but found ``.",
                 ]
                 const filteredDiagnostics = diagnostics.filter(diagnostic => !messagesToSuppress.includes(diagnostic.message));

--- a/packages/language/src/definition-provider.ts
+++ b/packages/language/src/definition-provider.ts
@@ -10,7 +10,7 @@ export class SnakeskinDefinitionProvider extends DefaultDefinitionProvider {
 
     constructor(services: SnakeskinServices) {
         super(services);
-        this.ts = services.TypeScript;
+        this.ts = services.TypeScript.ts;
     }
 
     protected override collectLocationLinks(sourceCstNode: LeafCstNode, params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -188,7 +188,7 @@ function generateInclude(include: Include): Generated {
   // For now, I (unjustifiably) assume that all imported files have "- namespace [%fileName%]"
   // This makes it easier to map it to a "namespace import".
 
-  const namespace = normalizeId(include.path.replace('/index.ss', '').split('/').pop()!);
+  const namespace = normalizeId(include.path.replace('/index.ss', '').replace('.ss', '').split('/').pop()!);
 
   const name = traceToNode(include, 'renderAs')(namespace);
   // TODO: resolve the absolute path to the ".ss.ts" virtual file

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -74,7 +74,7 @@ function generateDirective(directive: Directive, ctx: GenerationContext): Genera
 }
 
 function generateTemplate(template: Template, ctx: GenerationContext): Generated {
-  const params = joinTracedToNode(template, 'params')(template.params, generateParam, { separator: ', ' });
+  const params = joinTracedToNode(template, 'params')(template.params, generateParam, { separator: ', ' })!;
 
   let superClass: Generated;
   if (template.extends) {
@@ -90,9 +90,9 @@ function generateTemplate(template: Template, ctx: GenerationContext): Generated
   const constructorBody = joinTracedToNode(template, 'body')(otherDirectives, (dir) => generateDirective(dir, ctx))!;
 
 
-  if (!constructorBody.isEmpty()) {
+  if (!constructorBody.isEmpty() || !params.isEmpty()) {
     const classConstructor = expandToNode`
-      constructor() {`.appendNewLine()
+      constructor(${params}) {`.appendNewLine()
         .indent(['const self = this;', NL, constructorBody])
         .append('}')
         .appendNewLine();
@@ -118,7 +118,7 @@ function generateTemplate(template: Template, ctx: GenerationContext): Generated
   ctx.externalBlocks[template.name] = [];
 
   return expandTracedToNode(template)
-    `export class ${traceToNode(template, 'name')(template.name)}(${params}) ${superClass != undefined ? 'extends ' : ''}${superClass} {`.appendNewLine()
+    `export class ${traceToNode(template, 'name')(template.name)} ${superClass != undefined ? 'extends ' : ''}${superClass} {`.appendNewLine()
       .indent([classBody])
       .append('}')
       .appendNewLine();

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -220,7 +220,7 @@ function generateCall(call: Call, ctx: GenerationContext): Generated {
 }
 
 function generateVoid(voidNode: Void): Generated {
-  return expandTracedToNode(voidNode, 'content')`void ${voidNode.content}`.appendNewLine();
+  return expandTracedToNode(voidNode, 'content')`void (${voidNode.content})`.appendNewLine();
 }
 
 function generateTag(tag: Tag, ctx: GenerationContext): Generated {

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -5,15 +5,41 @@
  * This tutorial is the main source followed for this module: https://www.typefox.io/blog/code-generation-for-langium-based-dsls-3/
  */
 
-import { traceToNode, expandTracedToNode, joinTracedToNode, toStringAndTrace } from 'langium/generate';
+import { traceToNode, expandTracedToNode, joinTracedToNode, toStringAndTrace, expandToNode, NL, joinToNode, expandTracedToNodeIf } from 'langium/generate';
 import { type Generated, type TraceRegion } from 'langium/generate';
-import type { Directive, Const, Parameter, Template, Module, Block } from "../generated/ast";
+import { type Directive, type Const, type Parameter, type Template, type Module, type Block, type ReferencePath, isBlock, isConst } from "../generated/ast";
+
+type GenerationContext = {
+  insideTemplate: boolean;
+  insideBlock: boolean;
+  /**
+   * Holds blocks nested inside other blocks since they need to be flattened in the generated class.
+   * Their code generation will be delegated to the end of the template generation.
+   */
+  nestedBlocks: Block[];
+  /**
+   * Holds any blocks declared outside a template but with "- block index->div()" syntax,
+   * since they can only generated while actually generating the template code.
+   * Their code generation will be delegated until the template is found.
+   * The record key is the template name.
+   */
+  externalBlocks: Record<string, Block[]>;
+}
+function getDefaultContext(): GenerationContext {
+  return {
+    insideTemplate: false,
+    insideBlock: false,
+    nestedBlocks: [],
+    externalBlocks: {},
+  };
+}
 
 /**
  * Generates TypeScript code (with a source map) for a given Snakeskin module.
  */
 export function generateTypeScript(module: Module): { text:string, trace: TraceRegion } | undefined {
-  const directives = joinTracedToNode(module, 'directives')(module.directives, generateDirective);
+  const ctx = getDefaultContext();
+  const directives = joinTracedToNode(module, 'directives')(module.directives, (dir) => generateDirective(dir, ctx));
   if (directives == undefined) {
     return undefined;
   }
@@ -22,7 +48,7 @@ export function generateTypeScript(module: Module): { text:string, trace: TraceR
 }
 
 export type DirectiveGenerators = {
-  [D in Directive as D["$type"]]: (directive: D) => Generated;
+  [D in Directive as D["$type"]]: (directive: D, ctx: GenerationContext) => Generated;
 };
 
 export const directiveGenerators: Partial<DirectiveGenerators> = {
@@ -31,22 +57,58 @@ export const directiveGenerators: Partial<DirectiveGenerators> = {
   Block: generateBlock,
 };
 
-function generateDirective(directive: Directive): Generated {
+function generateDirective(directive: Directive, ctx: GenerationContext): Generated {
   // The casting is required because TypeScript is not smart enough
-  return directiveGenerators[directive.$type]?.(directive as never);
+  return directiveGenerators[directive.$type]?.(directive as never, ctx);
 }
 
-function generateTemplate(template: Template): Generated {
+function generateTemplate(template: Template, ctx: GenerationContext): Generated {
   const params = joinTracedToNode(template, 'params')(template.params, generateParam, { separator: ', ' });
-  const body = joinTracedToNode(template, 'body')(template.body, generateDirective);
 
-  // TODO: Although a template technically generates a JavaScript function in Snakeskin,
-  // the generated code here should be class instead so they can inherit other templates
-  // and blocks can be instance methods with overriding support, simplifying the IntelliSense.
-  // Also, "self" (in blocks) should be simply aliased to "this"
+  let superClass: Generated;
+  if (template.extends) {
+    superClass = generateReferencePath(template.extends);
+  }
+
+  ctx = { ...ctx, insideTemplate: true };
+  const isValidClassField = (dir: Directive) => [isBlock, isConst].some(f => f(dir));
+  const classFieldDirectives = template.body.filter(dir => isValidClassField(dir));
+  const otherDirectives = template.body.filter(dir => !isValidClassField(dir));
+
+  const classBody = joinTracedToNode(template, 'body')(classFieldDirectives, (dir) => generateDirective(dir, ctx))!;
+  const constructorBody = joinTracedToNode(template, 'body')(otherDirectives, (dir) => generateDirective(dir, ctx))!;
+
+
+  if (!constructorBody.isEmpty()) {
+    const classConstructor = expandToNode`
+      constructor() {`.appendNewLine()
+        .indent(['const self = this;', NL, constructorBody])
+        .append('}')
+        .appendNewLine();
+
+    classBody.contents.unshift(classConstructor);
+  }
+
+  // Add external blocks (if any)
+  const external = ctx.externalBlocks[template.name] ?? [];
+  classBody.appendIf(
+    external.length > 0,
+    joinToNode(external, block => generateBlock(block, ctx))
+  );
+
+  // Flatten nested blocks (if any)
+  classBody.appendIf(
+    ctx.nestedBlocks.length > 0,
+    joinToNode(ctx.nestedBlocks, block => generateBlock(block, ctx))
+  );
+
+  // Reset the modified context
+  ctx.nestedBlocks = [];
+  ctx.externalBlocks[template.name] = [];
+
   return expandTracedToNode(template)
-    `export function ${traceToNode(template, 'name')(template.name)}(${params}) {`.appendNewLine()
-      .indent(body?.contents)
+    `export class ${traceToNode(template, 'name')(template.name)}(${params}) ${superClass != undefined ? 'extends ' : ''}${superClass} {`.appendNewLine()
+      .indent([classBody])
       .append('}')
       .appendNewLine();
 }
@@ -58,20 +120,56 @@ function generateParam(param: Parameter): Generated {
   return expandTracedToNode(param)`${traceToNode(param, 'name')(param.name)}${separator}${defaultValue}`;
 }
 
-function generateConst(constNode: Const): Generated {
+function generateConst(constNode: Const, ctx: GenerationContext): Generated {
   const name = traceToNode(constNode, 'name')(constNode.name);
   const initialValue = traceToNode(constNode, 'initialValue')(constNode.initialValue);
-  return expandTracedToNode(constNode)`const ${name} = ${initialValue};`.appendNewLine();
+  if (ctx.insideTemplate && !ctx.insideBlock) {
+    return expandTracedToNode(constNode)`readonly ${name} = ${initialValue};`.appendNewLine();
+  } else {
+    return expandTracedToNode(constNode)`const ${name} = ${initialValue};`.appendNewLine();
+  }
 }
 
-function generateBlock(block: Block): Generated {
-  const params = joinTracedToNode(block, 'params')(block.params, generateParam, { separator: ', ' });
-  const body = joinTracedToNode(block, 'body')(block.body, generateDirective);
+function generateBlock(block: Block, ctx: GenerationContext): Generated {
+  if (block.container && !ctx.insideTemplate) {
+    // Found an external block. Delegate its generation to when we find its template.
+    ctx.externalBlocks[block.container.$refText] ??= [];
+    ctx.externalBlocks[block.container.$refText].push(block);
+    return;
+  }
+  if (ctx.insideBlock) {
+    // Found a nested block. Delegate its generation to when we're back to the template root.
+    ctx.nestedBlocks.push(block);
+    return;
+  }
+
+  const params = joinTracedToNode(block, 'params')(block.params, generateParam, { separator: ', ' })!;
+  ctx = { ...ctx, insideBlock: true };
+  const body = joinTracedToNode(block, 'body')(block.body, (dir) => generateDirective(dir, ctx))!;
+
+  const preamble = expandTracedToNodeIf(!body.isEmpty() && ctx.insideTemplate, block)`
+    const self = this;`?.appendNewLine();
 
   return expandTracedToNode(block)
-    `function ${traceToNode(block, 'name')(block.name)}(${params}) {`
+    `${ctx.insideTemplate ? '' : 'function '}${traceToNode(block, 'name')(block.name)}(${params}) {`
       .appendNewLine()
-      .indent(body?.contents)
+      .indent([preamble, body])
       .append('}')
       .appendNewLine();
+}
+
+const normalizeId = (id: string): string => id.replace(/[^\w]/g, '_');
+
+
+function generateReferencePath(path: ReferencePath): Generated {
+  const name = normalizeId(path.name);
+
+  const generated = expandTracedToNode(path)`${name}`;
+  if (path.next) {
+    const next = generateReferencePath(path.next);
+    generated
+      .append('.')
+      .appendTraced(path, 'next')(next);
+  }
+  return generated;
 }

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -1,0 +1,77 @@
+/**
+ * IMPORTANT NOTE: This generator is NOT intended to generate correct/runnable code.
+ * The only purpose is to mimic the semantics of Snakeskin as closely as possible to get diagnostics from TS.
+ *
+ * This tutorial is the main source followed for this module: https://www.typefox.io/blog/code-generation-for-langium-based-dsls-3/
+ */
+
+import { traceToNode, expandTracedToNode, joinTracedToNode, toStringAndTrace } from 'langium/generate';
+import { type Generated, type TraceRegion } from 'langium/generate';
+import type { Directive, Const, Parameter, Template, Module, Block } from "../generated/ast";
+
+/**
+ * Generates TypeScript code (with a source map) for a given Snakeskin module.
+ */
+export function generateTypeScript(module: Module): { text:string, trace: TraceRegion } | undefined {
+  const directives = joinTracedToNode(module, 'directives')(module.directives, generateDirective);
+  if (directives == undefined) {
+    return undefined;
+  }
+
+  return toStringAndTrace(directives);
+}
+
+export type DirectiveGenerators = {
+  [D in Directive as D["$type"]]: (directive: D) => Generated;
+};
+
+export const directiveGenerators: Partial<DirectiveGenerators> = {
+  Template: generateTemplate,
+  Const: generateConst,
+  Block: generateBlock,
+};
+
+function generateDirective(directive: Directive): Generated {
+  // The casting is required because TypeScript is not smart enough
+  return directiveGenerators[directive.$type]?.(directive as never);
+}
+
+function generateTemplate(template: Template): Generated {
+  const params = joinTracedToNode(template, 'params')(template.params, generateParam, { separator: ', ' });
+  const body = joinTracedToNode(template, 'body')(template.body, generateDirective);
+
+  // TODO: Although a template technically generates a JavaScript function in Snakeskin,
+  // the generated code here should be class instead so they can inherit other templates
+  // and blocks can be instance methods with overriding support, simplifying the IntelliSense.
+  // Also, "self" (in blocks) should be simply aliased to "this"
+  return expandTracedToNode(template)
+    `export function ${traceToNode(template, 'name')(template.name)}(${params}) {`.appendNewLine()
+      .indent(body?.contents)
+      .append('}')
+      .appendNewLine();
+}
+
+function generateParam(param: Parameter): Generated {
+  const defaultValue = param.defaultValue ? traceToNode(param, 'defaultValue')(param.defaultValue) : '';
+  const separator = defaultValue ? ' = ' : '';
+
+  return expandTracedToNode(param)`${traceToNode(param, 'name')(param.name)}${separator}${defaultValue}`;
+}
+
+function generateConst(constNode: Const): Generated {
+  const name = traceToNode(constNode, 'name')(constNode.name);
+  const initialValue = traceToNode(constNode, 'initialValue')(constNode.initialValue);
+  return expandTracedToNode(constNode)`const ${name} = ${initialValue};`.appendNewLine();
+}
+
+function generateBlock(block: Block): Generated {
+  const params = joinTracedToNode(block, 'params')(block.params, generateParam, { separator: ', ' });
+  const body = joinTracedToNode(block, 'body')(block.body, generateDirective);
+
+  return expandTracedToNode(block)
+    `function ${traceToNode(block, 'name')(block.name)}(${params}) {`
+      .appendNewLine()
+      .indent(body?.contents)
+      .append('}')
+      .appendNewLine();
+}

--- a/packages/language/src/generator/generators.ts
+++ b/packages/language/src/generator/generators.ts
@@ -163,7 +163,7 @@ export class TypeScriptGenerationService implements Partial<DirectiveGenerators>
       const self = this;`?.appendNewLine();
 
     return expandTracedToNode(block)
-      `${ctx.insideTemplate ? '' : 'function '}${traceToNode(block, 'name')(block.name)}(${params}) {`
+      `${ctx.insideTemplate ? '' : 'function '}${traceToNode(block, 'name')(block.name)}(${params}): string {`
       .appendNewLine()
       .indent([preamble, body])
       .append('}')

--- a/packages/language/src/generator/index.ts
+++ b/packages/language/src/generator/index.ts
@@ -1,0 +1,2 @@
+export * from './generators';
+export * from './utils';

--- a/packages/language/src/generator/sourcemap.ts
+++ b/packages/language/src/generator/sourcemap.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+
+// This file is not actually used anywhere.
+// It is left here just as a reference for how source-to-generated position mapping could be done using
+// the "source-map" library in the future, in case it proves to be worth it (performance-wise).
+// https://www.typefox.io/blog/code-generation-for-langium-based-dsls-3/
+
+// It can also be done manually using a Segment Tree data structure:
+// https://github.com/PinkyJie/data-structure-ts/blob/master/segment-tree/segment-tree.ts
+// without depending on the source-map library
+
+import { TreeStreamImpl, AstUtils } from 'langium';
+import { SourceMapConsumer, SourceMapGenerator, StartOfSourceMap } from 'source-map';
+import { generateTypeScript } from '.';
+import { Module } from '../generated/ast';
+
+const module = AstUtils.findRootNode(node) as Module;
+const { uri } = AstUtils.getDocument(node).textDocument;
+
+const ts = generateTypeScript(module);
+
+const {text, trace} = ts;
+const mapper = new SourceMapGenerator(<StartOfSourceMap>{ file: uri });
+const sourceDefinitionText = module.$cstNode?.text ?? '';
+mapper.setSourceContent(uri, sourceDefinitionText);
+
+new TreeStreamImpl(trace, r => r.children ?? [], { includeRoot: true }).forEach(r => {
+    if (!r.sourceRegion
+        || !r.targetRegion
+        || r.children?.[0].targetRegion.offset === r.targetRegion.offset /* if the first child starts at the same position like this (potentially encompassing) region, skip this one and continue with the child(ren) */
+    ) {
+        return;
+    }
+
+    const sourceStart = r.sourceRegion.range?.start;
+    const targetStart = r.targetRegion.range?.start;
+
+    const sourceEnd = r.sourceRegion?.range?.end;
+    const sourceText = sourceEnd && sourceDefinitionText.length >= r.sourceRegion.end
+        ? sourceDefinitionText.substring(r.sourceRegion.offset, r.sourceRegion.end) : ''
+
+    sourceStart && targetStart && mapper.addMapping({
+        original:  { line: sourceStart.line + 1, column: sourceStart.character },
+        generated: { line: targetStart.line + 1, column: targetStart.character },
+        source: uri,
+        // name: /^[A-Za-z_]$/.test(sourceText) ? sourceText.toLowerCase() : undefined
+    });
+
+    // const sourceEnd = r.sourceRegion?.range?.end;
+    // const sourceText = sourceEnd && sourceDefinitionText.length >= r.sourceRegion.end
+    //     ? sourceDefinitionText.substring(r.sourceRegion.offset, r.sourceRegion.end) : ''
+    const targetEnd = r.targetRegion?.range?.end;
+    const targetText = targetEnd && text.length >= r.targetRegion.end
+        ? text.substring(r.targetRegion.offset, r.targetRegion.end) : ''
+
+    sourceEnd && targetEnd && !r.children && sourceText && targetText
+            && !/\s/.test(sourceText) && !/\s/.test(targetText)
+            && mapper.addMapping({
+        original:  { line: sourceEnd.line + 1, column: sourceEnd.character },
+        generated: { line: targetEnd.line + 1, column: targetEnd.character},
+        source: uri
+    });
+});
+
+const consumer = await SourceMapConsumer.fromSourceMap(mapper);
+
+if (range) {
+    const position = consumer.generatedPositionFor({
+        line: range.start.line,
+        column: range.start.character,
+        source: uri
+    });
+}
+
+// Additionally, the following needs to be added to ESBuild plugins:
+// {
+//     name: 'copy-sourcemap-wasm',
+//     setup(build) {
+//         build
+//         build.onEnd(() => {
+//             const wasmPath = new URL(import.meta.resolve('source-map/lib/mappings.wasm'));
+//             fs.copyFileSync(wasmPath.pathname, './out/language/mappings.wasm');
+//         })
+//     }
+// }

--- a/packages/language/src/generator/utils.ts
+++ b/packages/language/src/generator/utils.ts
@@ -1,0 +1,78 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import chalk from 'chalk';
+import type { AstNode, LangiumCoreServices, LangiumDocument } from 'langium';
+import { URI } from 'langium';
+import type { TextRegion, TraceRegion } from 'langium/generate';
+
+/**
+ * Given an offset in the source (Snakeskin) document and a sourcemap (trace object)
+ * to the generated TypeScript, returns the corresponding offset (if any) in the
+ * generated file to be used when querying with the TypeScript language service.
+ */
+export function mapSourceOffsetToGenerated(sourceOffset: number, map: TraceRegion): TextRegion | null {
+    if (!map.sourceRegion) return null;
+    if (map.sourceRegion.offset === sourceOffset) {
+        return map.targetRegion;
+    }
+    for (const child of map.children ?? []) {
+        const mapping = mapSourceOffsetToGenerated(sourceOffset, child);
+        if (mapping) {
+            return mapping;
+        }
+    }
+    return null;
+}
+
+// The following functions are mostly CLI utils copied from the template and not moved to the appropriate package yet.
+// They are left here just as a reference for now
+
+export async function extractDocument(fileName: string, services: LangiumCoreServices): Promise<LangiumDocument> {
+    const extensions = services.LanguageMetaData.fileExtensions;
+    if (!extensions.includes(path.extname(fileName))) {
+        console.error(chalk.yellow(`Please choose a file with one of these extensions: ${extensions}.`));
+        process.exit(1);
+    }
+
+    if (!fs.existsSync(fileName)) {
+        console.error(chalk.red(`File ${fileName} does not exist.`));
+        process.exit(1);
+    }
+
+    const document = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
+
+    return document;
+}
+
+export async function extractDocuments(fileOrDirName: string, services: LangiumCoreServices): Promise<LangiumDocument[]> {
+    if (!fs.existsSync(fileOrDirName)) {
+        console.error(chalk.red(`No such file or directory: ${fileOrDirName}.`));
+        process.exit(1);
+    }
+    if (!fs.lstatSync(fileOrDirName).isDirectory()) {
+        return [await extractDocument(fileOrDirName, services)];
+    }
+    const extensions = services.LanguageMetaData.fileExtensions;
+    const files = fs.readdirSync(fileOrDirName, { encoding:'utf8', recursive: true })
+                    .filter(file => extensions.includes(path.extname(file)));
+    return Promise.all(files.map(file => extractDocument(path.join(fileOrDirName, file), services)));
+}
+
+
+export async function extractAstNode<T extends AstNode>(fileName: string, services: LangiumCoreServices): Promise<T> {
+    return (await extractDocument(fileName, services)).parseResult?.value as T;
+}
+
+interface FilePathData {
+    destination: string,
+    name: string
+}
+
+export function extractDestinationAndName(filePath: string, destination: string | undefined): FilePathData {
+    filePath = path.basename(filePath, path.extname(filePath)).replace(/[.-]/g, '');
+    return {
+        destination: destination ?? path.join(path.dirname(filePath), 'generated'),
+        name: path.basename(filePath)
+    };
+}

--- a/packages/language/src/hover-provider.ts
+++ b/packages/language/src/hover-provider.ts
@@ -16,7 +16,7 @@ export class HoverProvider extends AstNodeHoverProvider {
 
     constructor(services: SnakeskinServices) {
         super(services);
-        this.ts = services.TypeScript;
+        this.ts = services.TypeScript.ts;
     };
 
     // by default, it tries to find the declaration, which we do not resolve yet, so we override the wrapper function
@@ -31,7 +31,7 @@ export class HoverProvider extends AstNodeHoverProvider {
     }
 
     // The actual logic of getting hover content for a specific node
-    override async getAstNodeHoverContent(node: AstNode): Promise<Hover|undefined> {
+    override async getAstNodeHoverContent(node: AstNode): Promise<Hover | undefined> {
         let range = node.$cstNode?.range;
 
         if (isTag(node)) {
@@ -44,19 +44,19 @@ export class HoverProvider extends AstNodeHoverProvider {
             }
 
             if (vueTag) {
-                return {contents: generateDocumentation(vueTag, undefined, true), range};
+                return { contents: generateDocumentation(vueTag, undefined, true), range };
             }
 
             const htmlTag = getDefaultHTMLDataProvider().provideTags()
                 .find(tag => tag.name.toLowerCase() === name);
             if (htmlTag) {
-                return {contents: generateDocumentation(htmlTag, undefined, true), range};
+                return { contents: generateDocumentation(htmlTag, undefined, true), range };
             }
             if (name === '?') {
-                return {contents: 'Placeholder tag. Will be removed during translation.', range};
+                return { contents: 'Placeholder tag. Will be removed during translation.', range };
             }
         } else if (isAttribute(node)) {
-            const {key} = node;
+            const { key } = node;
             if (!key) return;
             const normalizedKey = key.replace(/^:/, '').replace(/^@/, '').toLowerCase();
 
@@ -67,7 +67,7 @@ export class HoverProvider extends AstNodeHoverProvider {
 
             const vueGlobalAttr = this.vueData.globalAttributes?.find(attr => attr.name.toLowerCase() === node.key);
             if (vueGlobalAttr) {
-                return {contents: generateDocumentation(vueGlobalAttr, undefined, true), range};
+                return { contents: generateDocumentation(vueGlobalAttr, undefined, true), range };
             }
 
             const tagName = node.$container.tagName?.toLowerCase() ?? '';
@@ -75,21 +75,21 @@ export class HoverProvider extends AstNodeHoverProvider {
             if (vueTag) {
                 const attr = vueTag.attributes?.find(attr => normalizedKey === attr.name.toLowerCase());
                 if (attr) {
-                    return {contents: generateDocumentation(attr, undefined, true), range};
+                    return { contents: generateDocumentation(attr, undefined, true), range };
                 }
             }
 
             const attrs = getDefaultHTMLDataProvider().provideAttributes(tagName);
             const attr = attrs.find(attr => normalizedKey === attr.name.toLowerCase());
             if (attr) {
-                return {contents: generateDocumentation(attr, undefined, true), range};
+                return { contents: generateDocumentation(attr, undefined, true), range };
             }
         } else if (isReferencePath(node)) {
             const uri = AstUtils.getDocument(node).textDocument.uri;
             if (node.name === '%fileName%') {
-                return {contents: path.basename(uri, '.ss'), range};
+                return { contents: path.basename(uri, '.ss'), range };
             } else if (node.name === '%dirName%') {
-                return {contents: path.basename(path.dirname(uri)), range};
+                return { contents: path.basename(path.dirname(uri)), range };
             }
         } else if (isConst(node)) {
             const module = AstUtils.findRootNode(node) as Module;

--- a/packages/language/src/parser/snakeskin-lexer.ts
+++ b/packages/language/src/parser/snakeskin-lexer.ts
@@ -39,44 +39,44 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 	// TODO: remove this override after https://github.com/eclipse-langium/langium/pull/1708 is released
 	protected override dedentMatcher(text: string, offset: number, tokens: IToken[], groups: Record<string, IToken[]>): ReturnType<CustomPatternMatcherFunc> {
 		if (!this.isStartOfLine(text, offset)) {
-				return null;
+			return null;
 		}
 
 		const { currIndentLevel, prevIndentLevel, match } = this.matchWhitespace(text, offset, tokens, groups);
 
 		if (currIndentLevel >= prevIndentLevel) {
-				// bigger indentation (should be matched by indent)
-				// or same indentation level (should be matched by whitespace and ignored)
-				return null;
+			// bigger indentation (should be matched by indent)
+			// or same indentation level (should be matched by whitespace and ignored)
+			return null;
 		}
 
 		const matchIndentIndex = this.indentationStack.lastIndexOf(currIndentLevel);
 
 		// Any dedent must match some previous indentation level.
 		if (matchIndentIndex === -1) {
-				this.diagnostics.push({
-						severity: 'error',
-						message: `Invalid dedent level ${currIndentLevel} at offset: ${offset}. Current indentation stack: ${this.indentationStack}`,
-						offset,
-						length: match?.[0]?.length ?? 0,
-						line: this.getLineNumber(text, offset),
-						column: 1
-				});
-				return null;
+			this.diagnostics.push({
+				severity: 'error',
+				message: `Invalid dedent level ${currIndentLevel} at offset: ${offset}. Current indentation stack: ${this.indentationStack}`,
+				offset,
+				length: match?.[0]?.length ?? 0,
+				line: this.getLineNumber(text, offset),
+				column: 1
+			});
+			return null;
 		}
 
 		const numberOfDedents = this.indentationStack.length - matchIndentIndex - 1;
 		const newlinesBeforeDedent = text.substring(0, offset).match(/[\r\n]+$/)?.[0].length ?? 1;
 
 		for (let i = 0; i < numberOfDedents; i++) {
-				const token = this.createIndentationTokenInstance(
-						this.dedentTokenType,
-						text,
-						'',  // Dedents are 0-width tokens
-						offset - (newlinesBeforeDedent - 1), // Place the dedent after the first new line character
-				);
-				tokens.push(token);
-				this.indentationStack.pop();
+			const token = this.createIndentationTokenInstance(
+				this.dedentTokenType,
+				text,
+				'',  // Dedents are 0-width tokens
+				offset - (newlinesBeforeDedent - 1), // Place the dedent after the first new line character
+			);
+			tokens.push(token);
+			this.indentationStack.pop();
 		}
 
 		// Token already added, let the dedentation now be consumed as whitespace (if any) and ignored
@@ -211,7 +211,7 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 		} else if (tokenType.name === 'JS_EXPR') {
 			tokenType.PATTERN = (text, offset, tokens, groups) => {
 				if (tokens.length < 3) return null;
-				const [{tokenType: {name: parenOrComma}}, {tokenType: {name: id}}, {tokenType: {name: eq}}] = tokens.slice(-3);
+				const [{ tokenType: { name: parenOrComma } }, { tokenType: { name: id } }, { tokenType: { name: eq } }] = tokens.slice(-3);
 				if (eq !== '=' || id !== 'ID' || !['L_PAREN', 'COMMA', 'AT'].includes(parenOrComma)) {
 					return null;
 				}
@@ -231,7 +231,7 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 				// The " |" part is to support single line attribute values as well
 				const originalRegex = /(?<=\s(return|\+?=|if|switch|for|throw|unless|- target|\?|>|<!)\s).+?(?=$|\s+\|\s+)/my;
 				originalRegex.lastIndex = offset;
-				const singleLineMatch =  originalRegex.exec(text);
+				const singleLineMatch = originalRegex.exec(text);
 				if (singleLineMatch?.[0].endsWith('&')) {
 					// The value is multiline, so need to continue until consuming until " .\n"
 					const multilineRegex = /(?<=\s(return|\+?=|if|switch|for|throw|unless|- target|\?|<!) ).+?\s+\.$/smy;
@@ -255,7 +255,7 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 export class SnakeskinLexer extends IndentationAwareLexer {
 	override tokenize(text: string): LexerResult {
 		const result = super.tokenize(text);
-		let {errors, hidden, tokens} = result;
+		let { errors, hidden, tokens } = result;
 
 		// remove any indent/dedent tokens sandwiched between 2 TEXT tokens
 		for (let i = 0; i < tokens.length - 2; i++) {

--- a/packages/language/src/parser/snakeskin-lexer.ts
+++ b/packages/language/src/parser/snakeskin-lexer.ts
@@ -44,7 +44,7 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 
 		const { currIndentLevel, prevIndentLevel, match } = this.matchWhitespace(text, offset, tokens, groups);
 
-		if (currIndentLevel >= prevIndentLevel || match == null) {
+		if (currIndentLevel >= prevIndentLevel) {
 				// bigger indentation (should be matched by indent)
 				// or same indentation level (should be matched by whitespace and ignored)
 				return null;

--- a/packages/language/src/parser/snakeskin-lexer.ts
+++ b/packages/language/src/parser/snakeskin-lexer.ts
@@ -208,7 +208,7 @@ export class SnakeskinTokenBuilder extends IndentationAwareTokenBuilder<Snakeski
 				return [text.substring(offset, i)];
 			}
 			tokenType.LINE_BREAKS = true;
-		} else if (tokenType.name === 'PARAM_DEFAULT_VALUE') {
+		} else if (tokenType.name === 'JS_EXPR') {
 			tokenType.PATTERN = (text, offset, tokens, groups) => {
 				if (tokens.length < 3) return null;
 				const [{tokenType: {name: parenOrComma}}, {tokenType: {name: id}}, {tokenType: {name: eq}}] = tokens.slice(-3);

--- a/packages/language/src/snakeskin-module.ts
+++ b/packages/language/src/snakeskin-module.ts
@@ -9,6 +9,7 @@ import { TypeScriptServices } from './typescript-service.js';
 import { SnakeskinDefinitionProvider } from './definition-provider.js';
 import { SnakeskinWorkspaceManager } from './workspace-manager.js';
 import { SnakeskinFoldingRangeProvider } from './folding-ranges.js';
+import { TypeScriptGenerationService } from './generator/generators.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -17,7 +18,10 @@ export type SnakeskinAddedServices = {
     validation: {
         SnakeskinValidator: SnakeskinValidator
     },
-    TypeScript: TypeScriptServices,
+    TypeScript: {
+        ts: TypeScriptServices;
+        generator: TypeScriptGenerationService;
+    };
 }
 
 export type SnakeskinSharedServices = {
@@ -51,7 +55,10 @@ export const SnakeskinModule: Module<SnakeskinServices, PartialLangiumServices &
         DefinitionProvider: (services) => new SnakeskinDefinitionProvider(services),
         FoldingRangeProvider: (services) => new SnakeskinFoldingRangeProvider(services),
     },
-    TypeScript: (services) => new TypeScriptServices(services),
+    TypeScript: {
+        ts: (services) => new TypeScriptServices(services),
+        generator: (services) => new TypeScriptGenerationService(services),
+    },
 };
 
 export const SnakeskinSharedModule: Module<LangiumSharedServices, SnakeskinSharedServices> = {

--- a/packages/language/src/snakeskin-validator.ts
+++ b/packages/language/src/snakeskin-validator.ts
@@ -24,7 +24,7 @@ export class SnakeskinValidator {
     private ts: TypeScriptServices;
 
     constructor(services: SnakeskinServices) {
-        this.ts = services.TypeScript;
+        this.ts = services.TypeScript.ts;
     }
 
     /**
@@ -33,7 +33,7 @@ export class SnakeskinValidator {
      */
     validateAttributesMissingBar(attr: Attribute, accept: ValidationAcceptor): void {
         if (attr.$cstNode == null) return;
-        const {range: {start, end}, text} = attr.$cstNode;
+        const { range: { start, end }, text } = attr.$cstNode;
         if (start.line === end.line) {
             // single-line attribute
             return;
@@ -50,7 +50,7 @@ export class SnakeskinValidator {
         });
         // When only the value is multi-line, there are usually no other attributes after it anyway
         const isValueMultiline = lines[0]?.endsWith(' &') ?? false;
-        const isLastInMultiline =  lineWithMatchingIndent === lines.length - 1 - 1 && lines.length > 2;
+        const isLastInMultiline = lineWithMatchingIndent === lines.length - 1 - 1 && lines.length > 2;
 
         if (lineWithMatchingIndent !== -1 && !isLastInMultiline && !isValueMultiline) {
             const line = start.line + lineWithMatchingIndent;
@@ -62,8 +62,8 @@ export class SnakeskinValidator {
                 {
                     node: attr,
                     range: {
-                        start: {line, character: startChar},
-                        end: {line: line + 1, character: endChar}
+                        start: { line, character: startChar },
+                        end: { line: line + 1, character: endChar }
                     },
                 }
             );

--- a/packages/language/src/snakeskin.langium
+++ b/packages/language/src/snakeskin.langium
@@ -111,12 +111,16 @@ Parameter:
     // TODO: any JS expression
 ;
 
-Template:
-    '-' async?=ASYNC? 'template'
-    name=ID
+fragment Parameters:
     L_PAREN
         (params+=Parameter (COMMA params+=Parameter)*)?
     R_PAREN
+;
+
+Template:
+    '-' async?=ASYNC? 'template'
+    name=ID
+    Parameters
     ('extends' extendsWith?=AT? extends=ReferencePath)?
     Body?
 ;
@@ -129,9 +133,7 @@ Template:
 Placeholder:
     '-' 'placeholder'
     name=ID
-    L_PAREN
-        (params+=Parameter (COMMA params+=Parameter)*)?
-    R_PAREN
+    Parameters
     ('extends' extendsWith?=AT? extends=ReferencePath)?
     Body
 ;
@@ -140,9 +142,7 @@ Block:
     '-' 'block'
     (container=[Template] '->')?
     name=ID
-    (L_PAREN
-        (params+=Parameter (COMMA params+=Parameter)*)?
-    R_PAREN)?
+    Parameters?
     Body?
 ;
 

--- a/packages/language/src/snakeskin.langium
+++ b/packages/language/src/snakeskin.langium
@@ -107,7 +107,7 @@ Namespace:
 Parameter:
     usesWith?=AT? // Actually this line currently never matches because it would get detected as "ATTR_KEY"
     name=(ID|ATTR_KEY) // hack: ATTR_KEY because it can sometimes start with '@' and have default value, hence matching the wrong token
-    ('=' defaultValue=PARAM_DEFAULT_VALUE)?
+    ('=' defaultValue=JS_EXPR)?
     // TODO: any JS expression
 ;
 
@@ -294,7 +294,7 @@ Continue: {infer Continue} '-' 'continue';
 
 ForEach:
     '-' 'forEach'
-    AT? collection=(ID | JS_Array | ATTR_KEY) // TODO: any JS expression
+    AT? collection=(ID | JS_EXPR | ATTR_KEY) // TODO: any JS expression
     '=>'
     name=ID
     (COMMA idx=ID)?
@@ -472,8 +472,6 @@ TagName returns string:
     INTERPOLATION
 ;
 
-JS_Array returns string: L_BRAC (STRING (COMMA STRING)*)? R_BRAC;
-
 /**
  * The token builder will be overridden to choose one based on existing inside "& ."
  */
@@ -483,7 +481,7 @@ AttrVal returns string:
 terminal FUNC_PREFIX: /(?<=\n\s*)\(\)\s*=>\s/;
 terminal TEXT: /(?<=[\n\r]+\s+)(?!=+=|\/\*)[^\-\s<:?].*?(?=\r?\n)/s;
 terminal COMMA: /,/;
-terminal PARAM_DEFAULT_VALUE: /JS Object, will be overwritten in the TokenBuilder/;
+terminal JS_EXPR: /JS Object, will be overwritten in the TokenBuilder/;
 // Workaround for JavaScript expressions, matches till end of line
 /**
  * When inside & . context, attr ends with " | " or " .\n"

--- a/packages/language/src/snakeskin.langium
+++ b/packages/language/src/snakeskin.langium
@@ -16,6 +16,7 @@ entry Module:
 Directive:
     Namespace |
     Template |
+    Decorator |
     // Interface |
     Placeholder |
     Block |
@@ -32,6 +33,7 @@ Directive:
 
     Var |
     Const |
+    Global |
 
     If |
     ElseIf |
@@ -125,6 +127,11 @@ Template:
     Body?
 ;
 
+Decorator:
+    '-' AT global?=AT? funcName=ID
+    L_BRAC (args+=JS_EXPR (COMMA args+=JS_EXPR)*)? R_BRAC
+;
+
 // TODO: Interface
 
 /**
@@ -215,7 +222,10 @@ Const:
     '=' initialValue=AttrVal  // TODO: any JS expression
 ;
 
-// TODO: Global
+Global:
+    '-' AT AT name=ID
+    '=' initialValue=AttrVal
+;
 
 
 // ---------- VI. Logical directives ----------

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -194,13 +194,13 @@ export class TypeScriptServices {
     }
 
     /**
-     * Computes the content of the hover popup on a const directive
+     * Computes the content of the hover popup on a directive
      *
-     * @param fileName The file in which the user is currently hovering on a "const"
+     * @param fileName The file in which the user is currently hovering on a directive
      * @param ssOffset The text offset inside that file
      * @returns The content of the hover popup
      */
-    getConstHoverInfo(fileName: string, ssOffset: number): string | undefined {
+    getHoverInfo(fileName: string, ssOffset: number): string | undefined {
         fileName = TypeScriptServices.snakeskinUriToTsPath(fileName);
         const file = this.files.get(fileName);
         if (file == null) {
@@ -215,6 +215,10 @@ export class TypeScriptServices {
         const info = this.languageService.getQuickInfoAtPosition(fileName, tsOffset);
         const typeInfo = ts.displayPartsToString(info?.displayParts);
         const jsDoc = ts.displayPartsToString(info?.documentation);
+
+        if (typeInfo.length === 0) {
+            return jsDoc;
+        }
 
         return expandToString`
             \`\`\`ts

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -207,8 +207,8 @@ export class TypeScriptServices {
             return;
         }
 
-        const tsOffset = mapSourceOffsetToGenerated(ssOffset, file.trace)?.offset;
-        if (tsOffset == undefined) {
+        const tsOffset = mapSourceOffsetToGenerated(ssOffset, file.trace);
+        if (tsOffset == null) {
             return;
         }
 

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -105,7 +105,7 @@ export class TypeScriptServices {
      * Internal helper for {@link resolveSnakeskinInclude} to minmize repetition.
      */
     private resolveSnakeskinIncludeHelper(includePath: string, containingFile: URI, options: ts.CompilerOptions): URI[] {
-        const { resolvedModule } = ts.resolveModuleName(includePath, containingFile.toString(), options, TypeScriptServices.snakeskinModuleResolutionHost);
+        const { resolvedModule } = ts.resolveModuleName(includePath, containingFile.fsPath, options, TypeScriptServices.snakeskinModuleResolutionHost);
         let { resolvedFileName } = resolvedModule ?? {};
 
         if (resolvedFileName == null) return [];

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import ts from "typescript";
 import { globSync } from "glob";
 import { URI, DocumentState, type LangiumDocument } from "langium";
-import type { TraceRegion } from "langium/generate";
+import { expandToString, type TraceRegion } from "langium/generate";
 import type { SnakeskinServices } from "./snakeskin-module";
 import { mapSourceOffsetToGenerated, type TypeScriptGenerationService } from "./generator";
 import type { Module } from "./generated/ast";
@@ -213,6 +213,14 @@ export class TypeScriptServices {
         }
 
         const info = this.languageService.getQuickInfoAtPosition(fileName, tsOffset);
-        return "```ts\n" + ts.displayPartsToString(info?.displayParts) + "\n```";
+        const typeInfo = ts.displayPartsToString(info?.displayParts);
+        const jsDoc = ts.displayPartsToString(info?.documentation);
+
+        return expandToString`
+            \`\`\`ts
+            ${typeInfo}
+            \`\`\`
+            ${jsDoc}
+        `;
     }
 }

--- a/packages/language/src/typescript-service.ts
+++ b/packages/language/src/typescript-service.ts
@@ -189,4 +189,27 @@ export class TypeScriptServices {
             version: file?.version != null ? (file.version + 1) : 0,
         });
     }
+
+    /**
+     * Computes the content of the hover popup on a const directive
+     *
+     * @param fileName The file in which the user is currently hovering on a "const"
+     * @param ssOffset The text offset inside that file
+     * @returns The content of the hover popup
+     */
+    getConstHoverInfo(fileName: string, ssOffset: number): string | undefined {
+        fileName = TypeScriptServices.snakeskinUriToTsPath(fileName);
+        const file = this.files.get(fileName);
+        if (file == null) {
+            return;
+        }
+
+        const tsOffset = mapSourceOffsetToGenerated(ssOffset, file.trace)?.offset;
+        if (tsOffset == undefined) {
+            return;
+        }
+
+        const info = this.languageService.getQuickInfoAtPosition(fileName, tsOffset);
+        return "```ts\n" + ts.displayPartsToString(info?.displayParts) + "\n```";
+    }
 }


### PR DESCRIPTION
Added a generator that converts Snakeskin code to TypeScript and registered the generated code with a source map for tracing in the TypeScript service to be used for requesting IntelliSense features.
No IntelliSense features are implemented in this PR (to be done separately), and not all AST nodes are covered yet. Most of the important ones are, with the exception of `Tag`s.